### PR TITLE
docs: make README badge copy more general

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ We're always trying to learn how we can make Sourcery better. Let us know any th
 
 
 ## Badges
-Let the world know your project is using Sourcery to refactor with this badge:
+Let the world know your project is using Sourcery with this badge:
 
 [![Sourcery](https://img.shields.io/badge/Sourcery-enabled-brightgreen)](https://sourcery.ai)
 


### PR DESCRIPTION
## Summary\n- update the README badge intro copy to say projects are using Sourcery, instead of using Sourcery to refactor\n\n## Why\nThe README now presents Sourcery more broadly as an AI code reviewer and IDE assistant, so the badge section's wording is a bit narrower than the rest of the page. This small docs tweak keeps that copy aligned without changing the badge itself.\n\n## Verification\n- verified the README now reads: "Let the world know your project is using Sourcery with this badge:"